### PR TITLE
new MOVR/GLMR operation: "account_transactions"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# PyCharm IDE
+.idea/

--- a/PipRequirements.txt
+++ b/PipRequirements.txt
@@ -1,0 +1,2 @@
+eth_utils
+requests

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ A Python scraper for substrate chains that uses Subscan.
 
 ## Usage
 - copy config/sample_scrape_config.json to config/scrape_config.json and configure to your desire.
-- make sure there is a data/parachains folder
-- run
+- run "scrape.py"
 - corresponding files will be created in data/
 
 If a file already exists in data/, that operation will be skipped in subsequent runs.
@@ -37,6 +36,6 @@ API: https://docs.api.subscan.io/
 If you have a Subscan API key, you can put it in the main folder in a file called "subscan-key" and it will be applied to your calls.
 
 ### ParachainScraper
-This is a scraoer that knows how to use the SubscanWrapper to fetch data for a parachain and serialize it to disk.
+This is a scraper that knows how to use the SubscanWrapper to fetch data for a parachain and serialize it to disk.
 
 Currently it knows how to fetch addresses and extrinsics.

--- a/scrape.py
+++ b/scrape.py
@@ -11,9 +11,11 @@ from subscrape.db.subscrape_db import SubscrapeDB
 
 log_level = logging.INFO
 
+
 def moonscan_factory(chain):
     endpoint = f"https://api-{chain}.moonscan.io/api"
     return MoonscanWrapper(endpoint)
+
 
 def subscan_factory(chain):
     subscan_key = None
@@ -27,7 +29,10 @@ def subscan_factory(chain):
 
 def scraper_factory(name):
     if name == "moonriver" or name == "moonbeam":
-        db_path = f"data/parachains/{name}_"
+        db_path = f"data/parachains"
+        if not os.path.exists(db_path):
+            os.makedirs(db_path)
+        db_path += f'/{name}_'
         api = moonscan_factory(name)
         scraper = MoonbeamScraper(db_path, api)
         return scraper
@@ -36,6 +41,7 @@ def scraper_factory(name):
         api = subscan_factory(name)
         scraper = ParachainScraper(db, api)
         return scraper
+
 
 async def main():
     logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(message)s')
@@ -56,7 +62,6 @@ async def main():
             continue
         parachain_scraper = scraper_factory(key)
         await parachain_scraper.scrape(config[key])
-    
-    
+
 
 asyncio.run(main())

--- a/subscrape/scrapers/moonbeam_scraper.py
+++ b/subscrape/scrapers/moonbeam_scraper.py
@@ -1,8 +1,10 @@
+from datetime import datetime
 import os
 import logging
 import json
 import io
 from eth_utils import keccak
+
 
 class MoonbeamScraper:
     def __init__(self, db_path, api):
@@ -18,43 +20,73 @@ class MoonbeamScraper:
                 for contract in payload:
                     methods = payload[contract]
                     for method in methods:
-                        await self.fetch_transactions(contract, method)
+                        contract_method = f"{contract}_{method}"
+                        assert(contract_method not in self.transactions)
+                        self.transactions[contract_method] = {}
+                        processor = self.process_methods_in_transaction_factory(contract_method, method)
+                        await self.fetch_transactions(contract, processor, contract_method)
+            elif operation == "account_transactions":
+                if "accounts" in payload:
+                    for account in payload['accounts']:
+                        self.transactions[account] = {}
+                        processor = self.process_transactions_on_account_factory(account)
+                        await self.fetch_transactions(account, processor)
+                else:
+                    self.logger.error(f"'accounts' not listed in config for operation '{operation}'.")
             else:
                 self.logger.error(f"config contained an operation that does not exist: {operation}")            
                 exit
 
-    async def fetch_transactions(self, contract, method):
-        contract_method = f"{contract}_{method}"
-        assert(contract_method not in self.transactions)
+    async def fetch_transactions(self, address, processor, reference=None):
+        """Fetch all transactions for a given address (account/contract) and use the given processor method to filter
+        or post-process each transaction as we work through them. Optionally, use 'reference' to uniquely identify this
+        set of post-processed transaction data.
 
-        file_path = self.db_path + f"transactions_{contract_method}.json"
+        :param address: the moonriver/moonbeam account number of interest. This could be a basic account, or a contract
+        address, depending on the kind of transactions being analyzed.
+        :type address: str
+        :param processor: a method that is used to post-process every transaction for the given address as it is
+        retrieved from the API. Processing transactions as they come in, instead of storing all transaction data helps
+        cut down on required storage.
+        :type processor: function
+        :param reference: (optional) Unique identifier for this set of post-processed transaction data being created,
+        if necessary.
+        :type reference: str
+        """
+        if reference is None:
+            reference = address
+        else:
+            reference = reference.replace(" ", "_")
+        file_path = self.db_path + f"{reference}.json"
         if os.path.exists(file_path):
-            self.logger.warn(f"{file_path} already exists. Skipping.")
+            self.logger.warning(f"{file_path} already exists. Skipping.")
             return
 
-        self.logger.info(f"Fetching transactions {contract_method} from {self.api.endpoint}")
-
-        self.transactions[contract_method] = {}
-
-        processor = self.process_methods_in_transaction_factory(contract_method, method)
+        self.logger.info(f"Fetching transactions for {reference} from {self.api.endpoint}")
 
         params = {}
         params["module"] = "account"
         params["action"] = "txlist"
-        params["address"] = contract
+        params["address"] = address
         params["startblock"] = "1"
         params["endblock"] = "99999999"
         params["sort"] = "asc"
 
         await self.api.iterate_pages(processor, params=params)
 
-        payload = json.dumps(self.transactions[contract_method])
+        payload = json.dumps(self.transactions[reference], indent=4, sort_keys=False)
         file = io.open(file_path, "w")
         file.write(payload)
         file.close()
 
     def process_methods_in_transaction_factory(self, contract_method, method):
         def process_method_in_transaction(transaction):
+            """Process each transaction from a specific method of a contract, counting the number of transactions for
+            each account.
+
+            :param transaction: all details for a specific transaction on the specified contract.
+            :type transaction: dict
+            """
             if transaction["input"][0:10] == method:
                 address = transaction["from"]
                 if address not in self.transactions[contract_method]:
@@ -62,3 +94,21 @@ class MoonbeamScraper:
                 else:
                     self.transactions[contract_method][address] += 1
         return process_method_in_transaction
+
+    def process_transactions_on_account_factory(self, account):
+        def process_transaction_on_account(transaction):
+            """Process each transaction for an account, capturing the necessary info.
+
+            :param transaction: all details for a specific transaction on the specified account.
+            :type transaction: dict
+            """
+            timestamp = transaction['timeStamp']
+            acct_tx = {'utcdatetime': str(datetime.utcfromtimestamp(int(timestamp))), 'hash': transaction['hash'],
+                       'from': transaction['from'], 'to': transaction['to'], 'valueInWei': transaction['value'],
+                       'value': float(transaction['value'])/1000000000000000000, 'gas': transaction['gas'],
+                       'gasPrice': transaction['gasPrice'], 'gasUsed': transaction['gasUsed']}
+            self.transactions[account][timestamp] = acct_tx
+            # todo: interpret dex token swaps
+            # todo: interpret liquidity provisioning
+        return process_transaction_on_account
+

--- a/subscrape/scrapers/parachain_scrape_config.py
+++ b/subscrape/scrapers/parachain_scrape_config.py
@@ -1,5 +1,6 @@
 import copy
 
+
 class ParachainScrapeConfig:
     def __init__(self, config):
         self.filter = None
@@ -28,7 +29,6 @@ class ParachainScrapeConfig:
         if digits_per_sector is not None:
             self.digits_per_sector = digits_per_sector
 
-
     # creates a config that can be nested to lower layers
     def create_inner_config(self, config):
         result = copy.deepcopy(self)
@@ -39,6 +39,7 @@ class ParachainScrapeConfig:
     def _filter_factory(self, conditions):
         if conditions is None:
             return None
+
         def filter(extrinsic):
             for group in conditions:
                 for key in group:

--- a/subscrape/scrapers/parachain_scraper.py
+++ b/subscrape/scrapers/parachain_scraper.py
@@ -7,6 +7,7 @@ from tkinter import NONE
 from typing import List
 from subscrape.scrapers.parachain_scrape_config import ParachainScrapeConfig
 
+
 # A generic scraper for parachains
 class ParachainScraper:
 
@@ -81,7 +82,7 @@ class ParachainScraper:
     async def fetch_addresses(self):
         assert(len(self.addresses) == 0)
 
-        file_path = self.db_path + "adresses.json"
+        file_path = self.db_path + "addresses.json"
         if os.path.exists(file_path):
             self.logger.warn(f"{file_path} already exists. Skipping.")
             return
@@ -91,10 +92,9 @@ class ParachainScraper:
         method = "/api/v2/scan/accounts"
         url = self.endpoint + method
 
-        await self.api.iterate_pages(url, self.process_account,
-            list_key = "list")
+        await self.api.iterate_pages(url, self.process_account, list_key="list")
 
-        file_path = self.db_path + "adresses.json"
+        file_path = self.db_path + "addresses.json"
         payload = json.dumps(self.addresses)
         file = io.open(file_path, "w")
         file.write(payload)


### PR DESCRIPTION
### Description
* support new operation "account_transactions" for retrieving all transactions for an account. Structured so that I think support for filters and skipping can be added later.
* refactor moonbeam_scraper's "fetch_transactions" so that it can be used to retrieve transactions both for accounts and entire contract method (by pulling processor definition out).
* a little PEP8 cleanup and reStructured text docstrings for methods

### Testing
* to make sure your "transactions" operation still works, I ran subscrape.py using your example config file and it chugged through Solarbeam transactions. Looks like about 7935 unique addresses, so hopefully that matches your previous results.

### Future
* I'd suggest renaming your "transactions" operation to something like `contract_transactions`.
* I'd love to use your filtering module on moonriver/moonbeam, but it looks like you've only integrated it with ParachainScraper so far.