### PR TITLE
Feature/transfers

### DIFF
--- a/config/sample_scrape_config.json
+++ b/config/sample_scrape_config.json
@@ -1,6 +1,9 @@
 {
     "_version": 1,
     "kusama": {
+        "transfers": {
+            "F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29": "Treasury"
+        },
         "extrinsics": {
             "_filter": [{"block_timestamp": [{"<":1644796800}]}],
             "system": [

--- a/scrape.py
+++ b/scrape.py
@@ -65,7 +65,7 @@ async def main():
     for chain in chains:
         if chain.startswith("_"):
             if chain == "_version" and chains[chain] != 1:
-                logging.warn("config version != 1. It could contain runtime breaking contents")
+                logging.warning("config version != 1. It could contain runtime breaking contents")
             continue
         operations = chains[chain]
         chain_config = scrape_config.create_inner_config(operations)

--- a/subscrape/scrapers/moonbeam_scraper.py
+++ b/subscrape/scrapers/moonbeam_scraper.py
@@ -61,8 +61,24 @@ class MoonbeamScraper:
                         await self.fetch_transactions(contract, processor, contract_method)
             elif operation == "account_transactions":
                 account_transactions_payload = operations[operation]
+                account_transactions_config = chain_config.create_inner_config(contracts)
                 if "accounts" in account_transactions_payload:
-                    for account in account_transactions_payload['accounts']:
+                    accounts = account_transactions_payload['accounts']
+                    for account in accounts:
+                        # ignore metadata
+                        if account.startswith("_"):
+                            continue
+
+                        # deduce config
+                        if type(accounts) is dict:
+                            account_config = contract_config.create_inner_config(methods[method])
+                        else:
+                            account_config = contract_config
+
+                        if account_config.skip:
+                            self.logger.info(f"Config asks to skip account {account}")
+                            continue
+
                         self.transactions[account] = {}
                         processor = self.process_transactions_on_account_factory(account)
                         await self.fetch_transactions(account, processor)

--- a/subscrape/scrapers/parachain_scraper.py
+++ b/subscrape/scrapers/parachain_scraper.py
@@ -71,6 +71,15 @@ class ParachainScraper:
             await self.fetch_transfers(account, account_config)
 
     async def fetch_transfers(self, account, call_config):
+        """
+        Fetches the treansfers for a single account and writes them to the db.
+
+        :param account: The account to scrape
+        :type account: str
+        :param call_config: The call_config which has the filter set
+        :type call_config: ScrapeConfig
+        """
+
         # Todo: determine if the address is valid or emit a warning
 
         self.db.set_active_transfers_account(account)

--- a/subscrape/scrapers/parachain_scraper.py
+++ b/subscrape/scrapers/parachain_scraper.py
@@ -16,45 +16,107 @@ class ParachainScraper:
         self.api = api
 
     async def scrape(self, operations, chain_config):
+        """Performs all the operations it was given by determining the operation and then calling the corresponding 
+        method.
+        
+        :param operations: A dict of operations and it's subdicts
+        :type operations: dict
+        :param chain_config: the `ScrapeConfig` to bubble down configuration properties
+        :type chain_config: ScrapeConfig
+        """
+
         for operation in operations:
             if operation.startswith("_"):
                 continue
 
             if operation == "extrinsics":
                 modules = operations[operation]
-                extrinsic_config = chain_config.create_inner_config(modules)
-
-                for module in modules:
-                    # ignore metadata
-                    if module.startswith("_"):
-                        continue
-
-                    calls = modules[module]
-                    module_config = extrinsic_config.create_inner_config(calls)
-                    
-                    for call in calls:
-                        # ignore metadata
-                        if call.startswith("_"):
-                            continue
-
-                        # deduce config
-                        if type(calls) is dict:
-                            call_config = module_config.create_inner_config(calls[call])
-                        else:
-                            call_config = module_config
-
-                        # config wants us to skip this call?
-                        if call_config.skip:
-                            self.logger.info(f"Config asks to skip {module} {call}")
-                            continue
-
-                        # go
-                        await self.fetch_extrinsics(module, call, call_config)
-            elif operation == "addresses":
-                await self.fetch_addresses()
+                await self.scrape_extrinsics(modules, chain_config)
+            elif operation == "transfers":
+                accounts = operations[operation]
+                await self.scrape_transfers(accounts, chain_config)
             else:
                 self.logger.error(f"config contained an operation that does not exist: {operation}")            
                 exit
+
+    async def scrape_transfers(self, accounts, chain_config):
+        """Scrapes all transfers that belong to the list of accounts.
+        
+        :param accounts: A dict of accounts on their names
+        :type accounts: dict
+        :param chain_config: the `ScrapeConfig`
+        :type chain_config: ScrapeConfig
+        """
+        accounts_config = chain_config.create_inner_config(accounts)
+
+        for account in accounts:
+            # ignore metadata
+            if account.startswith("_"):
+                continue
+            
+            # deduce config
+            if type(account) is dict:
+                account_config = accounts_config.create_inner_config(accounts[account])
+            else:
+                account_config = accounts_config
+
+            # config wants us to skip this call?
+            if account_config.skip:
+                self.logger.info(f"Config asks to skip account {account}")
+                continue
+    
+    async def fetch_transfers(self, account, call_config):
+        call_string = f"{call_module}_{call_name}"
+
+        if call_config.digits_per_sector is not None:
+            self.db.digits_per_sector = call_config.digits_per_sector
+        self.db.set_active_extrinsics_call(call_module, call_name)
+
+        self.logger.info(f"Fetching extrinsics {call_string} from {self.api.endpoint}")
+
+        method = "/api/scan/extrinsics"
+
+        self.db.dimension = ""
+        body = {"module": call_module, "call": call_name}
+        await self.api.iterate_pages(
+            method,
+            self.db.write_extrinsic,
+            list_key="extrinsics",
+            body=body,
+            filter=call_config.filter
+            )
+
+        self.db.flush_extrinsics()
+
+    async def scrape_extrinsics(self, modules, chain_config):
+        extrinsic_config = chain_config.create_inner_config(modules)
+
+        for module in modules:
+            # ignore metadata
+            if module.startswith("_"):
+                continue
+
+            calls = modules[module]
+            module_config = extrinsic_config.create_inner_config(calls)
+            
+            for call in calls:
+                # ignore metadata
+                if call.startswith("_"):
+                    continue
+
+                # deduce config
+                if type(calls) is dict:
+                    call_config = module_config.create_inner_config(calls[call])
+                else:
+                    call_config = module_config
+
+                # config wants us to skip this call?
+                if call_config.skip:
+                    self.logger.info(f"Config asks to skip {module} {call}")
+                    continue
+
+                # go
+                await self.fetch_extrinsics(module, call, call_config)
 
     async def fetch_extrinsics(self, call_module, call_name, call_config):
         call_string = f"{call_module}_{call_name}"
@@ -79,6 +141,15 @@ class ParachainScraper:
 
         self.db.flush_extrinsics()
 
+    def process_account(self, account):
+        account_display = account["account_display"]
+        address = account_display["address"]
+        self.addresses.append(address)
+        return True
+
+
+"""
+
     async def fetch_addresses(self):
         assert(len(self.addresses) == 0)
 
@@ -99,10 +170,4 @@ class ParachainScraper:
         file = io.open(file_path, "w")
         file.write(payload)
         file.close()
-
-    def process_account(self, account):
-        account_display = account["account_display"]
-        address = account_display["address"]
-        self.addresses.append(address)
-        return True
-
+"""

--- a/subscrape/scrapers/parachain_scraper.py
+++ b/subscrape/scrapers/parachain_scraper.py
@@ -82,7 +82,7 @@ class ParachainScraper:
         body = {"address": account}
         await self.api.iterate_pages(
             method,
-            self.db.write_transfers,
+            self.db.write_transfer,
             list_key="transfers",
             body=body,
             filter=call_config.filter


### PR DESCRIPTION
Introduces the ability to scrape transfers

Closes #2

### Usage:
Adds a new operation that can be used in parachains to scrape transfers from an account:

        "transfers": {
            "F3opxRbN5ZbjJNU511Kj2TLuzFcDq9BGduA9TgiECafpg29": "Treasury"
        },

Transfers will be stored in `data/parachains/<chain>_transfers/`