### PR TITLE
shim `setup.py` so editable install possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+import setuptools
+
+if __name__ == "__main__":
+    setuptools.setup()


### PR DESCRIPTION
I've previously used `setup.py` but noticed you were using a `pyproject.toml` instead so I thought I'd learn about the differences. I found this SO post describing how you could use a shim `setup.py` to still allow editable installs of the `subscrape` package. (I didn't even know editable installs were possible before!) Anyways, I've added in that shim to give us maximal utility in the future.
https://stackoverflow.com/questions/62983756/what-is-pyproject-toml-file-for 

contributes to #20