### PR TITLE
tune Moonscan rate limits

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/bin/sample_events.py
+++ b/bin/sample_events.py
@@ -27,8 +27,8 @@ async def main():
 
     logging.info("transforming...")
     db = SubscrapeDB(db_connection_string)
-    
-    events = db.query_events(chain = chain, module = module_name, event = event_name).all()
+
+    events = db.query_events(chain=chain, module=module_name, event=event_name).all()
 
     # print all event ids
     for event in events:

--- a/bin/scrape.py
+++ b/bin/scrape.py
@@ -4,7 +4,6 @@ import logging
 from pathlib import Path
 import platform
 import sys
-import time
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 import subscrape
 

--- a/subscrape/__init__.py
+++ b/subscrape/__init__.py
@@ -87,7 +87,7 @@ def scraper_factory(chain_name, chain_config: ScrapeConfig, db_factory: callable
             db_connection_string = "sqlite:///data/cache/default.db"
         else:
             db_connection_string = chain_config.db_connection_string
-        
+
         # create the database object
         if db_factory is None:
             db = SubscrapeDB(db_connection_string)

--- a/subscrape/apis/blockscout_wrapper.py
+++ b/subscrape/apis/blockscout_wrapper.py
@@ -6,7 +6,6 @@ from datetime import datetime
 import httpx
 import json
 import logging
-from ratelimit import limits, sleep_and_retry
 
 
 class BlockscoutWrapper:
@@ -18,8 +17,6 @@ class BlockscoutWrapper:
         self.semaphore = asyncio.Semaphore(5)
         self.lock = asyncio.Lock()
 
-    @sleep_and_retry                # be patient and sleep this thread to avoid exceeding the rate limit
-    # @limits(calls=5, period=1)      # No API limit stated on Blockscout website, so choose conservative 5 calls/sec
     async def __query(self, params, client=None):
         """Rate limited call to fetch another page of data from the Blockscout block explorer website
 
@@ -50,7 +47,7 @@ class BlockscoutWrapper:
                     await asyncio.sleep(1)
                 elif response.status_code != 200:
                     self.logger.info(f"Status Code: {response.status_code}")
-                    self.logger.info(response.headers)
+                    self.logger.info(response)
                     raise Exception(f"Error: {response.status_code}")
                 else:
                     should_request = False

--- a/subscrape/scrapers/parachain_scraper.py
+++ b/subscrape/scrapers/parachain_scraper.py
@@ -15,7 +15,7 @@ class ParachainScraper:
         self.api: SubscanWrapper = api
 
     async def scrape(self, operations, chain_config) -> list:
-        """Performs all the operations it was given by determining the operation and then calling the corresponding 
+        """Performs all the operations it was given by determining the operation and then calling the corresponding
         method.
 
         :param operations: A dict of operations and it's subdicts
@@ -47,7 +47,7 @@ class ParachainScraper:
                 exit
 
             items.extend(new_items)
-        
+
         return items
 
     async def scrape_module_calls(self, modules, chain_config, fetch_function) -> list:
@@ -82,7 +82,7 @@ class ParachainScraper:
                 calls = modules[module]
 
             module_config = extrinsic_config.create_inner_config(calls)
-            
+
             # if we want to scrape all calls, calls is None. In that case, we just set it to a list containing None
             if calls is None:
                 calls = [None]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -7,10 +7,10 @@ from subscrape.db.subscrape_db import SubscrapeDB
 
 @pytest.mark.asyncio
 async def test_fetch_events_list():
-    
+
     chain = "kusama"
     event_index = "14238250-39"
-    
+
     config = {
         chain: {
             "events-list": [
@@ -35,12 +35,12 @@ async def test_fetch_events_list():
     assert type(event.params) is list
 
     db.close()
-    
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("auto_hydrate", [True, False])
 async def test_fetch_and_hydrate_event(auto_hydrate):
-    
+
     chain = "kusama"
 
     config = {
@@ -75,15 +75,15 @@ async def test_fetch_and_hydrate_event(auto_hydrate):
 
 @pytest.mark.asyncio
 async def test_fetch_events_by_module_event():
-    
+
     chain = "kusama"
     module_name = "council"
     event_name = "proposed"
 
     config = {
-        chain:{
+        chain: {
             "_auto_hydrate": False,
-            "events":{
+            "events": {
                 module_name: [event_name]
             }
         }
@@ -98,7 +98,7 @@ async def test_fetch_events_by_module_event():
     logging.info("testing")
 
     db = SubscrapeDB()
-    events = db.query_events(chain = chain, module = module_name, event = event_name).all()
+    events = db.query_events(chain=chain, module=module_name, event=event_name).all()
 
     events = [e for e in events if e.id == "52631-4"]
     assert len(events) == 1, "Expected 1 event"
@@ -110,15 +110,15 @@ async def test_fetch_events_by_module_event():
 
 @pytest.mark.asyncio
 async def test_fetch_events_by_module():
-    
+
     chain = "kusama"
     module_name = "council"
     event_names = ["proposed", "voted"]
 
     config = {
-        "kusama":{
+        "kusama": {
             "_auto_hydrate": False,
-            "events":{
+            "events": {
                 "council": None,
             }
         }
@@ -134,13 +134,13 @@ async def test_fetch_events_by_module():
 
     db = SubscrapeDB()
 
-    events = db.query_events(chain = chain, module = module_name, event = event_names[0]).all()
+    events = db.query_events(chain=chain, module=module_name, event=event_names[0]).all()
     events = [e for e in events if e.id == "14966317-39"]
     assert len(events) == 1, "Expected 1 event"
     event: Event = events[0]
     assert event.extrinsic_id == '14966317-2'
 
-    events = db.query_events(chain = chain, module = module_name, event = event_names[1]).all()
+    events = db.query_events(chain=chain, module=module_name, event=event_names[1]).all()
     events = [e for e in events if e.id == "14938460-47"]
     assert len(events) == 1, "Expected 1 event"
     event = events[0]
@@ -151,11 +151,11 @@ async def test_fetch_events_by_module():
 
 @pytest.mark.asyncio
 async def test_fetch_events_by_address():
-    
+
     chain = "kusama"
 
     config = {
-        chain:{
+        chain: {
             "_auto_hydrate": False,
             "events": None,
             "_params": {
@@ -183,7 +183,7 @@ async def test_fetch_events_by_address():
 
 @pytest.mark.asyncio
 async def test_fetch_events_repeatedly():
-    
+
     chain = "kusama"
 
     config = {
@@ -229,7 +229,7 @@ async def test_fetch_events_stop_on_known_data():
     We counted the number of events in the database before and after the second scrape, and know exactly how many
     events there should be.
     """
-    
+
     chain = "kusama"
 
     config = {

--- a/tests/test_extrinsics.py
+++ b/tests/test_extrinsics.py
@@ -11,7 +11,7 @@ async def test_fetch_extrinsics_list():
     extrinsic_idx = "14238250-2"
     
     config = {
-        chain:{
+        chain: {
             "extrinsics-list":[
                 extrinsic_idx
             ],
@@ -44,7 +44,7 @@ async def test_fetch_and_hydrate_extrinsic(auto_hydrate):
     chain = "kusama"
 
     config = {
-        chain:{
+        chain: {
             "_auto_hydrate": auto_hydrate,
             "extrinsics": None,
             "_params": {
@@ -76,9 +76,9 @@ async def test_fetch_and_hydrate_extrinsic(auto_hydrate):
 async def test_fetch_extrinsics_by_module_call():
         
     config = {
-        "kusama":{
+        "kusama": {
             "_auto_hydrate": False,
-            "extrinsics":{
+            "extrinsics": {
                 "bounties": ["propose_bounty"]
             }
         }
@@ -93,7 +93,7 @@ async def test_fetch_extrinsics_by_module_call():
     logging.info("testing")
 
     db = SubscrapeDB()
-    extrinsics = db.query_extrinsics(module = "bounties", call = "propose_bounty").all()
+    extrinsics = db.query_extrinsics(module="bounties", call="propose_bounty").all()
 
     extrinsics = [e for e in extrinsics if e.id == "14061443-2"]
     assert len(extrinsics) == 1, "Expected 1 extrinsic"
@@ -125,13 +125,13 @@ async def test_fetch_extrinsics_by_module():
 
     db = SubscrapeDB()
 
-    extrinsics = db.query_extrinsics(module = "bounties", call = "propose_bounty")
+    extrinsics = db.query_extrinsics(module="bounties", call="propose_bounty")
     extrinsics = [e for e in extrinsics if e.id == "12935940-3"]
     assert len(extrinsics) == 1, "Expected 1 extrinsic"
     extrinsic = extrinsics[0]
     assert extrinsic.extrinsic_hash == '0x28b3e9dc097036a98b43b9792745be89d3fecbbca71200b45a2aba901c7cc5af'
 
-    extrinsics = db.query_extrinsics(module = "bounties", call = "extend_bounty_expiry")
+    extrinsics = db.query_extrinsics(module="bounties", call="extend_bounty_expiry")
     extrinsics = [e for e in extrinsics if e.id == "14534356-3"]
     assert len(extrinsics) == 1, "Expected 1 extrinsic"
     extrinsic = extrinsics[0]
@@ -139,13 +139,14 @@ async def test_fetch_extrinsics_by_module():
 
     db.close()
 
+
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_by_address():
     
     chain = "kusama"
 
     config = {
-        chain:{
+        chain: {
             "_auto_hydrate": False,
             "extrinsics": None,
             "_params": {
@@ -170,14 +171,13 @@ async def test_fetch_extrinsics_by_address():
     db.close()
 
 
-
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_repeatedly():
     
     chain = "kusama"
 
     config = {
-        chain:{
+        chain: {
             "_auto_hydrate": False,
             "extrinsics": None,
             "_params": {

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -33,13 +33,13 @@ async def test__decode_token_swap_transaction():
     for timestamp in transactions:
         tx = transactions[timestamp]
         if tx['hash'] == '0x066f0e5a15d4c0094caa83addf6e60ea35c21b9212dfdc998ca89809307c3b82':
-            logging.info(f'for hash {tx["hash"]} the full transaction is {tx}')
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
             assert tx['input_a_token_symbol'] == 'ZLK'
             assert tx['output_a_token_symbol'] == 'USDC'
             assert_value_within_range(tx['input_a_quantity'], 7.743865640456116)
             assert_value_within_range(tx['output_a_quantity'], 22.428698)
         elif tx['hash'] == '0x921e89b531d8ad251e065a5cedc2fdaeacd3ca5fd9120bfbef5c2c9054b22263':
-            logging.info(f'for hash {tx["hash"]} the full transaction is {tx}')
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
             assert tx['input_a_token_symbol'] == 'WMOVR'
             assert tx['output_a_token_symbol'] == 'USDC'
             assert_value_within_range(tx['input_a_quantity'], 1.519)
@@ -93,8 +93,4 @@ def assert_value_within_range(actual, expected, tolerance_percent=1):
     upper_limit = expected_float + tolerance
     assert actual_float >= lower_limit
     assert actual_float <= upper_limit
-
-
-test__decode_token_swap_transaction()
-
 


### PR DESCRIPTION
* better determination of when a Moonscan API rate limit had been hit, and then empirical testing of the appropriate rate limit when no API key is provided.
* debug statements print out times in milliseconds
* run GitHub actions for PR branches from forks also
* more PEP8 cleanup