### PR TITLE
add moonbeam_scraper unit tests

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         # python-version: ["3.7", "3.8", "3.9", "3.10"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.10"]
 
     steps:
       - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest
-          if [ -f PipRequirements.txt ]; then pip install -Ur PipRequirements.txt; fi
+          pip install -Ur PipRequirements.txt
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -8,7 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-#        python-version: ["3.7", "3.8", "3.9", "3.10"]
-        python-version: ["3.9"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/bin/scrape.py
+++ b/bin/scrape.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import logging
 from pathlib import Path
-import platform
 import sys
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 import subscrape
@@ -15,11 +14,12 @@ async def main():
     Will call `scraper_factory()` to retrieve the proper scraper for a chain.
     If `_version` in the config does not match the current version, a warning is logged.
     """
-    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
+    logging.basicConfig(level=log_level, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s (%(filename)s:%(lineno)s)')
 
     # httpx with asyncio can cause an "unclosed transport" error on Windows. A workaround is to set a different loop
     # policy. See https://github.com/encode/httpx/issues/914
-    if platform.system() == 'Windows':
+    # and https://github.com/encode/httpx/issues/914#issuecomment-622586610
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 8 and sys.platform.startswith('win'):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     # load config

--- a/subscrape/apis/moonscan_wrapper.py
+++ b/subscrape/apis/moonscan_wrapper.py
@@ -29,7 +29,7 @@ class MoonscanWrapper:
         self.min_wait_between_queries = 1 / self.max_calls_per_sec
         self.logger.info(f'Moonscan.io rate limit set to {self.max_calls_per_sec} API calls per second.'
                          f' Minimum wait time between queries is {self.min_wait_between_queries:.3f} seconds.')
-        if api_key is not None:
+        if api_key is None:
             api_key_sec_between_queries = 1 / MOONSCAN_MAX_CALLS_PER_SEC_WITH_AN_API_KEY
             self.logger.info(f'Moonscan.io rate limit could be {MOONSCAN_MAX_CALLS_PER_SEC_WITH_AN_API_KEY} calls/sec'
                              f' ({api_key_sec_between_queries:.3f} sec between queries) if you had an API key.')
@@ -87,9 +87,8 @@ class MoonscanWrapper:
                         should_request = False
                         if ('status' in response_json and response_json['status'] == "0") \
                                 or ('message' in response_json and response_json['message'] == "NOTOK"):
-                            self.logger.warning(f'Moonscan API query failed for {params=} because'
-                                                f' "{response_json["result"]}" at'
-                                                f' {datetime.now().strftime("%H:%M:%S.%f")[:-3]}')
+                            self.logger.warning(f'Moonscan API query failed with response "{response_json["result"]}"'
+                                                f' at {datetime.now().strftime("%H:%M:%S.%f")[:-3]} with {params=}')
                         else:
                             # We received a normal response.
                             # Check if we should sleep a little to avoid exceeding the rate limit

--- a/subscrape/apis/moonscan_wrapper.py
+++ b/subscrape/apis/moonscan_wrapper.py
@@ -111,9 +111,10 @@ class MoonscanWrapper:
         :param tx_filter: method that returns True if certain transactions should be filtered out of the results
         :type tx_filter: function
         """
-        done = False            # keep crunching until we are done
-        previous_block = 0      # to check if the iterator actually moved forward
-        count = 0               # counter for how many items we queried already
+        done = False             # keep crunching until we are done
+        previous_block = 0       # to check if the iterator actually moved forward
+        last_block_received = 0  # to compare most recent block to end block requested
+        count = 0                # counter for how many items we queried already
         if 'startblock' in params:
             start_block = int(params['startblock'])
         else:
@@ -132,6 +133,7 @@ class MoonscanWrapper:
 
             # process the elements
             for element in elements:
+                last_block_received = int(element['blockNumber'])
                 if tx_filter is not None and tx_filter(element):
                     continue
                 await element_processor(element)
@@ -141,7 +143,8 @@ class MoonscanWrapper:
             self.logger.debug(count)
 
             start_block = int(element["blockNumber"])
-            if start_block == previous_block:
+            end_block = int(params["endblock"])
+            if start_block == previous_block or last_block_received == end_block:
                 done = True
             previous_block = start_block
 

--- a/subscrape/apis/moonscan_wrapper.py
+++ b/subscrape/apis/moonscan_wrapper.py
@@ -37,7 +37,7 @@ class MoonscanWrapper:
         self.semaphore = asyncio.Semaphore(math.ceil(self.max_calls_per_sec))
         self.lock = asyncio.Lock()
 
-    async def _query(self, params, client=None):
+    async def __query(self, params, client=None):
         """Rate limited call to fetch another page of data from the Moonscan.io block explorer website
 
         :param params: Moonscan.io API call params that filter which transactions are returned.
@@ -102,7 +102,7 @@ class MoonscanWrapper:
         response_json = json.loads(response.text)
         return response_json
 
-    async def _iterate_pages(self, element_processor, params={}, tx_filter=None):
+    async def __iterate_pages(self, element_processor, params={}, tx_filter=None):
         """Repeatedly fetch transactions from Moonscan.io matching a set of parameters, iterating one html page at a
         time. Perform post-processing of each transaction using the `element_processor` method provided.
         :param element_processor: method to process each transaction as it is received
@@ -119,7 +119,7 @@ class MoonscanWrapper:
 
         while not done:
             params["startblock"] = start_block
-            response_obj = await self._query(params)
+            response_obj = await self.__query(params)
 
             if response_obj["status"] == "0":
                 self.logger.info(f"received empty result. message='{response_obj['message']}' and"
@@ -160,9 +160,9 @@ class MoonscanWrapper:
         params = {"module": "account", "action": "txlist", "address": address, "startblock": "1",
                   "endblock": "99999999", "sort": "asc"}
         if config and hasattr(config, 'filter'):
-            await self._iterate_pages(element_processor, params=params, tx_filter=config.filter)
+            await self.__iterate_pages(element_processor, params=params, tx_filter=config.filter)
         else:
-            await self._iterate_pages(element_processor, params=params)
+            await self.__iterate_pages(element_processor, params=params)
 
     async def get_contract_abi(self, contract_address):
         """Get a contract's ABI (so that its transactions can be decoded).
@@ -173,7 +173,7 @@ class MoonscanWrapper:
         :rtype: str or None
         """
         params = {"module": "contract", "action": "getabi", "address": contract_address}
-        response_dict = await self._query(params)   # will add on the optional API key
+        response_dict = await self.__query(params)   # will add on the optional API key
         if response_dict['status'] == "0" or response_dict['message'] == "NOTOK":
             self.logger.info(f'ABI not retrievable for {contract_address} because "{response_dict["result"]}"'
                              f' at {datetime.now().strftime("%H:%M:%S.%f")[:-3]}')
@@ -191,6 +191,6 @@ class MoonscanWrapper:
         :rtype: dict or None
         """
         params = {"module": "proxy", "action": "eth_getTransactionReceipt", "txhash": tx_hash}
-        response_dict = await self._query(params)   # will add on the optional API key
+        response_dict = await self.__query(params)   # will add on the optional API key
         # response_dict['result'] should contain a long string representation of the tx receipt.
         return response_dict['result']

--- a/subscrape/apis/subscan_wrapper.py
+++ b/subscrape/apis/subscan_wrapper.py
@@ -49,9 +49,9 @@ class SubscanWrapper:
         self.lock = asyncio.Lock()
 
         self._extrinsic_index_deducer = lambda e: e["extrinsic_index"]
-        #self._events_index_deducer = lambda e: f"{e['event_index']}"
+        # self._events_index_deducer = lambda e: f"{e['event_index']}"
         self._event_index_deducer = lambda e: f"{e['block_num']}-{e['event_idx']}"
-        #self._transfers_index_deducer = lambda e: f"{e['block_num']}-{e['event_idx']}"
+        # self._transfers_index_deducer = lambda e: f"{e['block_num']}-{e['event_idx']}"
         self._last_id_deducer = lambda e: e["id"]
         self._api_method_extrinsics = "/api/v2/scan/extrinsics"
         self._api_method_extrinsic = "/api/scan/extrinsic"
@@ -59,7 +59,7 @@ class SubscanWrapper:
         self._api_method_event = "/api/scan/event"
         self._api_method_events_call = "event_id"
 
-    @sleep_and_retry                # be patient and sleep this thread to avoid exceeding the rate limit
+    @sleep_and_retry  # be patient and sleep this thread to avoid exceeding the rate limit
     # @limits(calls=MAX_CALLS_PER_SEC, period=1)     # API limits us to 30 calls every second
     async def _query(self, method, headers={}, body={}, client=None):
         """Rate limited call to fetch another page of data from the Subscan.io block explorer website
@@ -84,7 +84,7 @@ class SubscanWrapper:
 
         response = None
         should_request = True
-        while should_request:   # loop until we get a response
+        while should_request:  # loop until we get a response
             before = datetime.now()
             async with self.semaphore:
                 response = await client.post(url, headers=headers, data=body)
@@ -114,15 +114,15 @@ class SubscanWrapper:
     # iterates through all pages until it processed all elements
     # or gets False from the processor
     async def _iterate_pages(
-        self,
-        method,
-        element_processor,
-        list_key,
-        last_id_deducer,
-        body={},
-        filter=None,
-        stop_on_known_data=True,
-        ) -> list:
+            self,
+            method,
+            element_processor,
+            list_key,
+            last_id_deducer,
+            body={},
+            filter=None,
+            stop_on_known_data=True,
+    ) -> list:
         """Repeatedly fetch transactions from Subscan.io matching a set of parameters, iterating one html page at a
         time. Perform post-processing of each transaction using the `element_processor` method provided.
         :param method: Subscan.io API call method.
@@ -156,7 +156,7 @@ class SubscanWrapper:
 
             data = await self._query(method, body=body)
             # determine the limit on the first run
-            if limit == 0: 
+            if limit == 0:
                 limit = data["count"]
                 self.logger.info(f"About to fetch {limit} entries.")
                 if limit == 0:
@@ -366,7 +366,7 @@ class SubscanWrapper:
             body=body,
             filter=config.filter,
             stop_on_known_data=config.stop_on_known_data,
-            )
+        )
 
         self.db.flush()
 
@@ -390,7 +390,7 @@ class SubscanWrapper:
         """
 
         items = []
-        
+
         self.logger.info("Building list of extrinsics to fetch...")
 
         already_fetched_extrinsics = self.db.query_extrinsics(chain=self.chain, extrinsic_ids=extrinsic_indexes).all()
@@ -418,7 +418,7 @@ class SubscanWrapper:
 
                     self.logger.debug(f"Spawning task for {extrinsic_index}")
                     future = asyncio.ensure_future(task)
-                    await asyncio.sleep(1/MAX_CALLS_PER_SEC)
+                    await asyncio.sleep(1 / MAX_CALLS_PER_SEC)
                     futures.append(future)
 
                 raw_extrinsics = await asyncio.gather(*futures)
@@ -527,7 +527,7 @@ class SubscanWrapper:
 
                     self.logger.debug(f"Spawning task for {event_index}")
                     future = asyncio.ensure_future(task)
-                    await asyncio.sleep(1/MAX_CALLS_PER_SEC)
+                    await asyncio.sleep(1 / MAX_CALLS_PER_SEC)
                     futures.append(future)
 
                 raw_events = await asyncio.gather(*futures)

--- a/subscrape/decode/decode_evm_log.py
+++ b/subscrape/decode/decode_evm_log.py
@@ -20,7 +20,7 @@ from subscrape.decode.decode_evm_transaction import convert_to_hex
 
 
 @lru_cache(maxsize=None)
-def _get_topic2abi(abi):
+def __get_topic2abi(abi):
     """
     get a list of topics in the abi
 
@@ -36,7 +36,7 @@ def _get_topic2abi(abi):
 
 
 @lru_cache(maxsize=None)
-def _get_hex_topic(t):
+def __get_hex_topic(t):
     """
     convert a log topic to a hex string
 
@@ -62,7 +62,7 @@ def decode_log(data, topics, abi):
     """
     if abi is not None:
         try:
-            topic2abi = _get_topic2abi(abi)
+            topic2abi = __get_topic2abi(abi)
 
             log = {
                 'address': None,  # Web3.toChecksumAddress(address),
@@ -70,7 +70,7 @@ def decode_log(data, topics, abi):
                 'blockNumber': None,
                 'data': data,
                 'logIndex': None,
-                'topics': [_get_hex_topic(_) for _ in topics],
+                'topics': [__get_hex_topic(_) for _ in topics],
                 'transactionHash': None,  # HexBytes(transactionHash),
                 'transactionIndex': None
             }

--- a/subscrape/decode/decode_evm_transaction.py
+++ b/subscrape/decode/decode_evm_transaction.py
@@ -101,7 +101,7 @@ def convert_to_hex(arg, target_schema):
 
 
 @lru_cache(maxsize=None)
-def _get_contract(address, abi):
+def __get_contract(address, abi):
     """
     This helps speed up execution of decoding across a large dataset by caching the contract object
     It assumes that we are decoding a small set, on the order of thousands, of target smart contracts
@@ -132,7 +132,7 @@ def decode_tx(address, input_data, abi):
     """
     if abi is not None:
         try:
-            (contract, abi) = _get_contract(address, abi)
+            (contract, abi) = __get_contract(address, abi)
             func_obj, func_params = contract.decode_function_input(input_data)
             target_schema = [a['inputs'] for a in abi if 'name' in a and a['name'] == func_obj.fn_name][0]
             decoded_func_params = convert_to_hex(func_params, target_schema)

--- a/subscrape/scrapers/moonbeam_scraper.py
+++ b/subscrape/scrapers/moonbeam_scraper.py
@@ -141,6 +141,9 @@ class MoonbeamScraper:
         else:
             reference = reference.replace(" ", "_")
 
+        if len(self.transactions[reference]) == 0:
+            return
+
         # Export the transactions to a JSON file
         json_file_path = self.db_path.parent / f'{self.db_path.stem}{reference}.json'
         if json_file_path.exists():     # delete and recreate the file

--- a/subscrape/scrapers/moonbeam_scraper.py
+++ b/subscrape/scrapers/moonbeam_scraper.py
@@ -511,15 +511,17 @@ class MoonbeamScraper:
         # validate that the exact amounts are somewhat similar to the contract input values
         #     (to make sure we're matching up the right values).
         input_tolerance = requested_input_quantity_float * 0.2  # 20% each side
-        if (exact_amount_in_float > requested_input_quantity_float + input_tolerance) \
-                or (exact_amount_in_float < requested_input_quantity_float - input_tolerance):
+        if amount_in != 0 \
+            and ((exact_amount_in_float > requested_input_quantity_float + input_tolerance)
+                 or (exact_amount_in_float < requested_input_quantity_float - input_tolerance)):
             self.logger.warning(f"For transaction {tx_hash} with contract {contract_address} method"
                                 f" {contract_method_name}, expected log decoded input quantity"
                                 f" {exact_amount_in_float} to be within 20% of the requested tx input quantity"
                                 f" {requested_input_quantity_float} but it's not.")
         output_tolerance = requested_output_quantity_float * 0.2  # 20% each side
-        if (exact_amount_out_float > requested_output_quantity_float + output_tolerance) \
-                or (exact_amount_out_float < requested_output_quantity_float - output_tolerance):
+        if amount_out != 0 \
+            and ((exact_amount_out_float > requested_output_quantity_float + output_tolerance)
+                 or (exact_amount_out_float < requested_output_quantity_float - output_tolerance)):
             self.logger.warning(f"For transaction {tx_hash} with contract {contract_address} method"
                                 f" {contract_method_name}, expected log decoded output quantity"
                                 f" {exact_amount_out_float} to be within 20% of the requested tx output quantity"
@@ -715,7 +717,8 @@ class MoonbeamScraper:
 
         # validate that the exact amounts are somewhat similar to the contract input values
         #     (to make sure we're matching up the right values).
-        if 'requested_input_a_quantity_float' in locals() and requested_input_a_quantity_float is not None:
+        if 'requested_input_a_quantity_float' in locals() and requested_input_a_quantity_float is not None \
+                and amount_in_a != 0:
             input_a_tolerance = exact_amount_in_a_float * 0.2  # 20% each side
             if (exact_amount_in_a_float > requested_input_a_quantity_float + input_a_tolerance) \
                     or (exact_amount_in_a_float < requested_input_a_quantity_float - input_a_tolerance):
@@ -723,7 +726,8 @@ class MoonbeamScraper:
                                     f" '{contract_method_name}', expected log decoded LP input A quantity"
                                     f" {exact_amount_in_a_float} to be within 20% of the requested tx input quantity"
                                     f" {requested_input_a_quantity_float} but it's not.")
-        if 'requested_input_b_quantity_float' in locals() and requested_input_b_quantity_float is not None:
+        if 'requested_input_b_quantity_float' in locals() and requested_input_b_quantity_float is not None \
+                and amount_in_b != 0:
             input_b_tolerance = exact_amount_in_b_float * 0.2  # 20% each side
             if (exact_amount_in_b_float > requested_input_b_quantity_float + input_b_tolerance) \
                     or (exact_amount_in_b_float < requested_input_b_quantity_float - input_b_tolerance):
@@ -731,7 +735,7 @@ class MoonbeamScraper:
                                     f" '{contract_method_name}', expected log decoded LP input B quantity"
                                     f" {exact_amount_in_b_float} to be within 20% of the requested tx input quantity"
                                     f" {requested_input_b_quantity_float} but it's not.")
-        if 'amount_out' in locals() and amount_out is not None:    # if variable 'amount_out' has been defined
+        if 'amount_out' in locals() and amount_out is not None and amount_out != 0:  # if 'amount_out' has been defined
             output_tolerance = exact_amount_out_float * 0.2  # 20% each side
             if (exact_amount_out_float > amount_out + output_tolerance) \
                     or (exact_amount_out_float < amount_out - output_tolerance):
@@ -890,22 +894,25 @@ class MoonbeamScraper:
         # validate that the exact amounts are somewhat similar to the contract input values
         #     (to make sure we're matching up the right values).
         input_tolerance = exact_amount_in_float * 0.2  # 20% each side
-        if (exact_amount_in_float > requested_input_quantity_float + input_tolerance) \
-                or (exact_amount_in_float < requested_input_quantity_float - input_tolerance):
+        if input_liquidity_amount != 0 \
+            and ((exact_amount_in_float > requested_input_quantity_float + input_tolerance)
+                 or (exact_amount_in_float < requested_input_quantity_float - input_tolerance)):
             self.logger.warning(f"For transaction {tx_hash} with contract {contract_address} method"
                                 f" '{contract_method_name}', expected log decoded LP input quantity"
                                 f" {exact_amount_in_float} to be within 20% of the requested tx input quantity"
                                 f" {requested_input_quantity_float} but it's not.")
         output_tolerance = exact_amount_out_a_float * 0.2  # 20% each side
-        if (exact_amount_out_a_float > requested_output_a_quantity_float + output_tolerance) \
-                or (exact_amount_out_a_float < requested_output_a_quantity_float - output_tolerance):
+        if amount_out_a != 0 \
+            and ((exact_amount_out_a_float > requested_output_a_quantity_float + output_tolerance)
+                 or (exact_amount_out_a_float < requested_output_a_quantity_float - output_tolerance)):
             self.logger.warning(f"For transaction {tx_hash} with contract {contract_address} method"
                                 f" '{contract_method_name}', expected log decoded LP output A quantity"
                                 f" {exact_amount_out_a_float} to be within 20% of the requested tx output quantity"
                                 f" {requested_output_a_quantity_float} but it's not.")
         output_tolerance = exact_amount_out_b_float * 0.2  # 20% each side
-        if (exact_amount_out_b_float > requested_output_b_quantity_float + output_tolerance) \
-                or (exact_amount_out_b_float < requested_output_b_quantity_float - output_tolerance):
+        if amount_out_b != 0 \
+            and ((exact_amount_out_b_float > requested_output_b_quantity_float + output_tolerance)
+                 or (exact_amount_out_b_float < requested_output_b_quantity_float - output_tolerance)):
             self.logger.warning(f"For transaction {tx_hash} with contract {contract_address} method"
                                 f" '{contract_method_name}', expected log decoded LP output B quantity"
                                 f" {exact_amount_out_b_float} to be within 20% of the requested tx output quantity"

--- a/subscrape/scrapers/scrape_config.py
+++ b/subscrape/scrapers/scrape_config.py
@@ -6,6 +6,7 @@ import copy
 class ScrapeConfig:
     def __init__(self, config):
         self.filter = None
+        self.filter_conditions = None
         self.processor_name = None
         self.skip = False
         self.params = None
@@ -31,6 +32,7 @@ class ScrapeConfig:
         filter_conditions = config.get("_filter", None)
         if filter_conditions is not None:
             self.filter = self._filter_factory(filter_conditions)
+            self.filter_conditions = filter_conditions
 
         processor_name = config.get("_processor", None)
         if processor_name is not None:
@@ -134,4 +136,5 @@ class ScrapeConfig:
                         else:
                             continue
             return False
+
         return filter

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -42,7 +42,7 @@ async def test_db():
         params={"param1": "value1"},
         finalized=True
     )
-    
+
     db.write_item(extrinsic)
     db.write_item(event)
     db.flush()

--- a/tests/test_extrinsics.py
+++ b/tests/test_extrinsics.py
@@ -6,13 +6,12 @@ import pytest
 
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_list():
-    
     chain = "kusama"
     extrinsic_idx = "14238250-2"
-    
+
     config = {
         chain: {
-            "extrinsics-list":[
+            "extrinsics-list": [
                 extrinsic_idx
             ],
         }
@@ -33,14 +32,13 @@ async def test_fetch_extrinsics_list():
     assert extrinsic.extrinsic_hash == '0x408aacc9a42189836d615944a694f4f7e671a89f1a30bf0977a356cf3f6c301c'
     assert extrinsic.origin_public_key == "1eb38b0d5178bc680c10a204f81164946a25078c6d3b5f6813cef61c3aef4843"
     assert type(extrinsic.params) is list
-    
+
     db.close()
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("auto_hydrate", [True, False])
 async def test_fetch_and_hydrate_extrinsic(auto_hydrate):
-
     chain = "kusama"
 
     config = {
@@ -52,7 +50,7 @@ async def test_fetch_and_hydrate_extrinsic(auto_hydrate):
             }
         }
     }
-    
+
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
     logging.info("wiping storage")
@@ -74,7 +72,6 @@ async def test_fetch_and_hydrate_extrinsic(auto_hydrate):
 
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_by_module_call():
-        
     config = {
         "kusama": {
             "_auto_hydrate": False,
@@ -83,7 +80,7 @@ async def test_fetch_extrinsics_by_module_call():
             }
         }
     }
-    
+
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
     logging.info("wiping storage")
@@ -99,22 +96,21 @@ async def test_fetch_extrinsics_by_module_call():
     assert len(extrinsics) == 1, "Expected 1 extrinsic"
     extrinsic = extrinsics[0]
     assert extrinsic.extrinsic_hash == '0x9f2a81d8d92884122d122d806276da7ff9b440a0a273bc3898cbd4072d5f62e1'
-    
+
     db.close()
 
 
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_by_module():
-    
     config = {
-        "kusama":{
+        "kusama": {
             "_auto_hydrate": False,
-            "extrinsics":{
+            "extrinsics": {
                 "bounties": None
             }
         }
     }
-    
+
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
     logging.info("wiping storage")
@@ -142,7 +138,6 @@ async def test_fetch_extrinsics_by_module():
 
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_by_address():
-    
     chain = "kusama"
 
     config = {
@@ -154,7 +149,7 @@ async def test_fetch_extrinsics_by_address():
             }
         }
     }
-    
+
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
     logging.info("wiping storage")
@@ -173,7 +168,6 @@ async def test_fetch_extrinsics_by_address():
 
 @pytest.mark.asyncio
 async def test_fetch_extrinsics_repeatedly():
-    
     chain = "kusama"
 
     config = {
@@ -185,7 +179,7 @@ async def test_fetch_extrinsics_repeatedly():
             }
         }
     }
-    
+
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(name)s - %(message)s')
 
     logging.info("wiping storage")

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -886,42 +886,196 @@ async def test__decode_add_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_sol
 # ######### REMOVE LIQUIDITY TESTS ############################
 # #############################################################
 
-# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
-# @pytest.mark.asyncio
-# async def test__decode_remove_liquidity_tx__():
-#     # also testing: Zenlink transactions
-#     test_acct = "XXXXXXXXXX"
-#     config = {
-#         "moonriver": {
-#             "account_transactions": {
-#                 "accounts": [
-#                     test_acct
-#                 ],
-#                 "_filter": [{"blockNumber": [{"==": }]}]
-#             }
-#         }
-#     }
-#
-#     logging.info(f"begin 'test__decode_remove_liquidity_tx__XXXXXXXXXXXXXXXX'"
-#                  f" scraping at {time.strftime('%X')}")
-#     items_scraped = await subscrape.scrape(config)
-#     assert len(items_scraped) >= 1
-#     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-#     transaction_found = False
-#     for timestamp in transactions:
-#         tx = transactions[timestamp]
-#         if tx['hash'] == 'XXXXXXXXXXX':
-#             transaction_found = True
-#             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-#             assert tx['input_a_token_symbol'] == 'ZLK-LP'
-#             assert tx['output_a_token_symbol'] == ''
-#             assert tx['output_b_token_symbol'] == ''
-#             _assert_value_within_range(tx['input_a_quantity'], )
-#             _assert_value_within_range(tx['output_a_quantity'], )
-#             _assert_value_within_range(tx['output_b_quantity'], )
-#         else:
-#             continue
-#     assert transaction_found
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_remove_liquidity_tx_Huckleberry__removeLiquidity():
+    # also testing: Huckleberry transactions
+    test_acct = "0x70981296c3358984f725bc5309aa82010e9b1726"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3646449}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Huckleberry__removeLiquidity'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) == 2
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x72fbcd10382557ca38e9e364b8c84445b285682c4da885b53d8d3fd65b14159d':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'HBLP'
+            assert tx['output_a_token_symbol'] == 'USDC.m'
+            assert tx['output_b_token_symbol'] == 'FINN'
+            _assert_value_within_range(tx['input_a_quantity'], 0.004711704579832789)
+            _assert_value_within_range(tx['output_a_quantity'], 367.022401)
+            _assert_value_within_range(tx['output_b_quantity'], 80321.169)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityWithPermit():
+    # also testing: Solarbeam transactions
+    test_acct = "0x2ec799f0b132c55322e66c9182aaf8deebba9b3a"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3613200}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityWithPermit'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x0c566c0957155781455503b19c9e00491acbc2b50f51ba76d8a0bd838a6b34e1':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'SLP'
+            assert tx['output_a_token_symbol'] == 'xcKSM'
+            assert tx['output_b_token_symbol'] == 'wstKSM'
+            _assert_value_within_range(tx['input_a_quantity'], 0.000072617172606002)
+            _assert_value_within_range(tx['output_a_quantity'], 77.644919692792)
+            _assert_value_within_range(tx['output_b_quantity'], 68.149221539094)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_remove_liquidity_tx_Huckleberry__removeLiquidityETH():
+    # also testing: Huckleberry transactions
+    test_acct = "0x05ecf530e15771089fd906e945b145cb08b734b3"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3652020}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Huckleberry__removeLiquidityETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xd4366cead6f31aa586c2a8dc66d05bd9b8b5c916b46f204b3e2aed85744d17ea':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'HBLP'
+            assert tx['output_a_token_symbol'] == 'BTC.m'
+            assert tx['output_b_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 0.000004849163902491)
+            _assert_value_within_range(tx['output_a_quantity'], 0.01114992)
+            _assert_value_within_range(tx['output_b_quantity'], 23.019578889273288912)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
+                    reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityETHSupportingFeeOnTransferTokens():
+    # also testing: Solarbeam transactions
+    test_acct = "0x9bdbdb4a8f7f816c87a67f5281484ed902c6b942"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3617506}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityETHSupportingFeeOnTransferTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x344c69b7e4bd841a133b3bde5109823626fc0615d856f53e9e049662dea2b4dd':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'SLP'
+            assert tx['output_a_token_symbol'] == 'SOLAR'
+            assert tx['output_b_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 0.009145503279233851)
+            _assert_value_within_range(tx['output_a_quantity'], 0.1786776673359355)
+            _assert_value_within_range(tx['output_b_quantity'], 0.000539861237073285)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
+                    reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityETHWithPermitSupportingFeeOnTransferTokens():
+    # also testing: Solarbeam transactions
+    test_acct = "0x0515dfd2394982b497766b9754c4399470c4258b"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3622264}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Solarbeam__removeLiquidityETHWithPermitSupportingFeeOnTransferTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x8c308f6a4a4f5b2aab730c9de0e366aff89deaf81951fce337073e164fabd4a9':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'SLP'
+            assert tx['output_a_token_symbol'] == 'MFAM'
+            assert tx['output_b_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 5000)
+            _assert_value_within_range(tx['output_a_quantity'], 414759.225434228099724903)
+            _assert_value_within_range(tx['output_b_quantity'], 68.448462559040137288)
+        else:
+            continue
+    assert transaction_found
 
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
@@ -998,6 +1152,44 @@ async def test__decode_remove_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_
         else:
             continue
     assert transaction_found
+
+
+# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
+# @pytest.mark.asyncio
+# async def test__decode_remove_liquidity_tx__():
+#     # also testing: Zenlink transactions
+#     test_acct = "XXXXXXXXXX"
+#     config = {
+#         "moonriver": {
+#             "account_transactions": {
+#                 "accounts": [
+#                     test_acct
+#                 ],
+#                 "_filter": [{"blockNumber": [{"==": }]}]
+#             }
+#         }
+#     }
+#
+#     logging.info(f"begin 'test__decode_remove_liquidity_tx__XXXXXXXXXXXXXXXX'"
+#                  f" scraping at {time.strftime('%X')}")
+#     items_scraped = await subscrape.scrape(config)
+#     assert len(items_scraped) >= 1
+#     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+#     transaction_found = False
+#     for timestamp in transactions:
+#         tx = transactions[timestamp]
+#         if tx['hash'] == 'XXXXXXXXXXX':
+#             transaction_found = True
+#             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+#             assert tx['input_a_token_symbol'] == 'ZLK-LP'
+#             assert tx['output_a_token_symbol'] == ''
+#             assert tx['output_b_token_symbol'] == ''
+#             _assert_value_within_range(tx['input_a_quantity'], )
+#             _assert_value_within_range(tx['output_a_quantity'], )
+#             _assert_value_within_range(tx['output_b_quantity'], )
+#         else:
+#             continue
+#     assert transaction_found
 
 
 # #############################################################

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -13,6 +13,27 @@ import subscrape
 
 
 @pytest.mark.asyncio
+async def test__extract_addresses_calling_contract_method():
+    # Specifically, adding liquidity to the Solarbeam DEX
+    config = {
+        "moonriver": {
+            "transactions": {
+                "0xaa30ef758139ae4a7f798112902bf6d65612045f": [
+                    "0xe8e33700"
+                ],
+                "_filter": [{"blockNumber": [{">=": 992929}, {"<=": 993002}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__process_method_in_transaction' scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 2
+    assert ('0x48630c63beba19bbdc6e57d7d9c98735f5dd3d37' in items_scraped)
+    assert ('0xad2b8e18cc7bddde1fe7e254d78abf1188b6c8f4' in items_scraped)
+
+
+@pytest.mark.asyncio
 async def test__decode_token_swap_transaction():
     test_acct = "0xBa4123F4b2da090aeCef69Fd0946D42Ecd4C788E"
     config = {

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -14,7 +14,7 @@ import subscrape
 
 @pytest.mark.asyncio
 async def test__extract_addresses_calling_contract_method():
-    # Specifically, adding liquidity to the Solarbeam DEX
+    # Specifically, adding liquidity to the Solarbeam DEX. Also test filter range on "blockNumber"
     config = {
         "moonriver": {
             "transactions": {
@@ -29,12 +29,13 @@ async def test__extract_addresses_calling_contract_method():
     logging.info(f"begin 'test__process_method_in_transaction' scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 2
-    assert ('0x48630c63beba19bbdc6e57d7d9c98735f5dd3d37' in items_scraped)
+    assert ('0x48630c63beba19bbdc6e57d7d9c98735f5dd3d37' in items_scraped)  # aROME-FRAX LP
     assert ('0xad2b8e18cc7bddde1fe7e254d78abf1188b6c8f4' in items_scraped)
 
 
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction():
+async def test__decode_token_swap_transaction__swapExactTokensForTokens():
+    # also testing: swap transaction on Solarbeam DEX. filter range on "timeStamp"
     test_acct = "0xBa4123F4b2da090aeCef69Fd0946D42Ecd4C788E"
     config = {
         "moonriver": {
@@ -47,19 +48,23 @@ async def test__decode_token_swap_transaction():
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction' scraping at {time.strftime('%X')}")
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactTokensForTokens'"
+                 f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
-    assert items_scraped[0] >= 2
+    assert len(items_scraped) >= 2
     transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
     for timestamp in transactions:
         tx = transactions[timestamp]
         if tx['hash'] == '0x066f0e5a15d4c0094caa83addf6e60ea35c21b9212dfdc998ca89809307c3b82':
+            transaction_found = True
             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
             assert tx['input_a_token_symbol'] == 'ZLK'
             assert tx['output_a_token_symbol'] == 'USDC'
             assert_value_within_range(tx['input_a_quantity'], 7.743865640456116)
             assert_value_within_range(tx['output_a_quantity'], 22.428698)
         elif tx['hash'] == '0x921e89b531d8ad251e065a5cedc2fdaeacd3ca5fd9120bfbef5c2c9054b22263':
+            transaction_found = True
             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
             assert tx['input_a_token_symbol'] == 'WMOVR'
             assert tx['output_a_token_symbol'] == 'USDC'
@@ -67,9 +72,207 @@ async def test__decode_token_swap_transaction():
             assert_value_within_range(tx['output_a_quantity'], 465.032663)
         else:
             continue
+    assert transaction_found
 
 
-def get_archived_transactions_from_json(address, chain='moonriver'):
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapExactTokensForETH():
+    # also testing: swap transaction on Solarbeam DEX. filter '==' on blockNumber
+    test_acct = "0x299cd1c791464827ddfb147612244a2c59da91a0"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3471171}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactTokensForETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x0f379919b8dff50c1d83cf92c3aa7eca75e5558251ecf99e9e7fb660faf74c95':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'FRAX'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            assert_value_within_range(tx['input_a_quantity'], 100)
+            assert_value_within_range(tx['output_a_quantity'], 11.526796881289545)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapExactETHForTokens():
+    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= order. two hop tx
+    test_acct = "0x8e7fbb49f436d0e8a50c02f631e729a57a9a0aca"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"<=": 3421768}, {">=": 3421760}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactETHForTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xf4a51bb43a24e5bf7047d563ec831762659a1535bdbcb056764ac4298f4d3b08':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'DOT.m'
+            assert_value_within_range(tx['input_a_quantity'], 1)
+            assert_value_within_range(tx['output_a_quantity'], 1.2598567127)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapExactTokensForTokensSupportingFeeOnTransferTokens():
+    # also testing: swap transaction on Huckleberry DEX. filter '==' on blockNumber
+    test_acct = "0x85cf0915c8d3695b03da739e3eaefd5388eb5eef"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3313868}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactTokensForTokensSupportingFeeOnTransferTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xbc065d9aa4fd90a0fb1df3ddfaab633cd3866e5dc069c6ce47f33593d3aa8972':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'BTC.m'
+            assert_value_within_range(tx['input_a_quantity'], 0.008232571613605909)
+            assert_value_within_range(tx['output_a_quantity'], 0.00000302)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapTokensForExactETH():
+    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= with equal block number. Two hops.
+    test_acct = "0xfc2f3c2b6872d6ad347e78f096026274326ab081"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"<=": 3427502}, {">=": 3427502}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapTokensForExactETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x1b036cd6d161622a5f610680b2fc15aee96103a4a884d9338ecb59f65b31753f':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'FTM.m'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            assert_value_within_range(tx['input_a_quantity'], 1.507652227912820355)
+            assert_value_within_range(tx['output_a_quantity'], 0.06)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapTokensForExactTokens():
+    # also testing: swap transaction on Huckleberry DEX. "timeStamp" range in <= >= order. Two hop.
+    test_acct = "0xfc2f3c2b6872d6ad347e78f096026274326ab081"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"timeStamp": [{"<=": 1672581700}, {">=": 1672581680}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapTokensForExactTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xbdacc65d82e8e7273e42ba3c0c33d3ec884809087c718fcd4076709577cbd2f7':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'BNB.m'
+            assert tx['output_a_token_symbol'] == 'FTM.m'
+            assert_value_within_range(tx['input_a_quantity'], 0.038442263813382655)
+            assert_value_within_range(tx['output_a_quantity'], 51.8294)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.asyncio
+async def test__decode_token_swap_transaction__swapTokensForExactTokens__no_entries_returned():
+    test_acct = "0xa00654efb77c7861f42b32de3590e9a51a5aff64"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"timeStamp": [{"<=": 1672603300}, {">=": 1672603280}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_transaction__swapTokensForExactTokens__no_entries_returned'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) == 0
+    transactions = get_archived_transactions_from_json(test_acct, 'moonriver', file_expected=False)
+    assert transactions is None
+
+
+def get_archived_transactions_from_json(address, chain='moonriver', file_expected=True):
     """Return a list of all transactions (dict by timestamp) read from the JSON file generated when scraping.
 
     :param address: the moonriver/moonbeam account number of interest. This could be a basic account, or a contract
@@ -77,18 +280,24 @@ def get_archived_transactions_from_json(address, chain='moonriver'):
     :type address: str
     :param chain: name of the specific chain that was scraped
     :type chain: str
+    :param file_expected: is a JSON file expected to be found?
+    :type file_expected: bool
+    :returns: json structure with the scraped transactions
+    :rtype: dict
     """
     # Import the transactions from JSON file
     json_file_name = f'{chain}_{address}.json'
     json_file_path = Path(repo_root / 'data' / 'parachains' / json_file_name).resolve()
-    assert json_file_path.is_file()
-    with json_file_path.open('r', encoding="UTF-8") as input_file:
-        data = json.load(input_file)
+    data = None
+    if file_expected:
+        assert json_file_path.is_file()
+        with json_file_path.open('r', encoding="UTF-8") as input_file:
+            data = json.load(input_file)
     return data
 
 
 def assert_value_within_range(actual, expected, tolerance_percent=1):
-    """Return a list of all transactions (dict by timestamp) read from the JSON file generated when scraping.
+    """Verify that an actual float value is within 'tolerance' % of expected float value (to avoid exact comparisons)
 
     :param actual: actual float value received
     :type actual: float
@@ -99,13 +308,13 @@ def assert_value_within_range(actual, expected, tolerance_percent=1):
     """
     if isinstance(actual, float):
         actual_float = actual
-    elif isinstance(actual, str):
+    elif isinstance(actual, str) or isinstance(actual, int):
         actual_float = float(actual)
     else:
         assert False
     if isinstance(expected, float):
         expected_float = expected
-    elif isinstance(expected, str):
+    elif isinstance(expected, str) or isinstance(expected, int):
         expected_float = float(expected)
     else:
         assert False

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -66,7 +66,7 @@ async def test__no_entries_returned():
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction_Solarbeam__swapExactTokensForTokens():
+async def test__decode_token_swap_tx_Solarbeam__swapExactTokensForTokens():
     # also testing: swap transaction on Solarbeam DEX. filter range on "timeStamp"
     test_acct = "0xBa4123F4b2da090aeCef69Fd0946D42Ecd4C788E"
     config = {
@@ -80,7 +80,7 @@ async def test__decode_token_swap_transaction_Solarbeam__swapExactTokensForToken
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction_Solarbeam__swapExactTokensForTokens'"
+    logging.info(f"begin 'test__decode_token_swap_tx_Solarbeam__swapExactTokensForTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 2
@@ -109,7 +109,7 @@ async def test__decode_token_swap_transaction_Solarbeam__swapExactTokensForToken
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction_Zenlink__swapExactTokensForTokens():
+async def test__decode_token_swap_tx_Zenlink__swapExactTokensForTokens():
     # also testing: swap transaction on Zenlink DEX. two hops.
     test_acct = "0x2b46c40b6d1f4d77a6719f92864cf40bb049e366"
     config = {
@@ -123,7 +123,7 @@ async def test__decode_token_swap_transaction_Zenlink__swapExactTokensForTokens(
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction_Zenlink__swapExactTokensForTokens'"
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapExactTokensForTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -145,21 +145,21 @@ async def test__decode_token_swap_transaction_Zenlink__swapExactTokensForTokens(
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapExactTokensForETH():
-    # also testing: swap transaction on Solarbeam DEX. filter '==' on blockNumber
-    test_acct = "0x299cd1c791464827ddfb147612244a2c59da91a0"
+async def test__decode_token_swap_tx_Zenlink__swapTokensForExactTokens():
+    # also testing: swap transaction on Zenlink DEX.
+    test_acct = "0x79a8a9ff5717248a5fc0f00cc9920bd4bba77823"
     config = {
         "moonriver": {
             "account_transactions": {
                 "accounts": [
                     test_acct
                 ],
-                "_filter": [{"blockNumber": [{"==": 3471171}]}]
+                "_filter": [{"blockNumber": [{"==": 1224237}]}]
             }
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactTokensForETH'"
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapTokensForExactTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -167,13 +167,13 @@ async def test__decode_token_swap_transaction__swapExactTokensForETH():
     transaction_found = False
     for timestamp in transactions:
         tx = transactions[timestamp]
-        if tx['hash'] == '0x0f379919b8dff50c1d83cf92c3aa7eca75e5558251ecf99e9e7fb660faf74c95':
+        if tx['hash'] == '0x3b10057c7d19702732e48d7ec63f1b4f2299dccef79780263d28edbe61e2ed29':
             transaction_found = True
             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-            assert tx['input_a_token_symbol'] == 'FRAX'
-            assert tx['output_a_token_symbol'] == 'WMOVR'
-            _assert_value_within_range(tx['input_a_quantity'], 100)
-            _assert_value_within_range(tx['output_a_quantity'], 11.526796881289545)
+            assert tx['input_a_token_symbol'] == 'USDC'
+            assert tx['output_a_token_symbol'] == 'WBTC'
+            _assert_value_within_range(tx['input_a_quantity'], 462.79385)
+            _assert_value_within_range(tx['output_a_quantity'], 0.01)
         else:
             continue
     assert transaction_found
@@ -181,115 +181,7 @@ async def test__decode_token_swap_transaction__swapExactTokensForETH():
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapExactETHForTokens():
-    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= order. two hop tx
-    test_acct = "0x8e7fbb49f436d0e8a50c02f631e729a57a9a0aca"
-    config = {
-        "moonriver": {
-            "account_transactions": {
-                "accounts": [
-                    test_acct
-                ],
-                "_filter": [{"blockNumber": [{"<=": 3421768}, {">=": 3421760}]}]
-            }
-        }
-    }
-
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactETHForTokens'"
-                 f" scraping at {time.strftime('%X')}")
-    items_scraped = await subscrape.scrape(config)
-    assert len(items_scraped) >= 1
-    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-    transaction_found = False
-    for timestamp in transactions:
-        tx = transactions[timestamp]
-        if tx['hash'] == '0xf4a51bb43a24e5bf7047d563ec831762659a1535bdbcb056764ac4298f4d3b08':
-            transaction_found = True
-            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-            assert tx['input_a_token_symbol'] == 'WMOVR'
-            assert tx['output_a_token_symbol'] == 'DOT.m'
-            _assert_value_within_range(tx['input_a_quantity'], 1)
-            _assert_value_within_range(tx['output_a_quantity'], 1.2598567127)
-        else:
-            continue
-    assert transaction_found
-
-
-@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
-@pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapExactTokensForTokensSupportingFeeOnTransferTokens():
-    # also testing: swap transaction on Huckleberry DEX. filter '==' on blockNumber
-    test_acct = "0x85cf0915c8d3695b03da739e3eaefd5388eb5eef"
-    config = {
-        "moonriver": {
-            "account_transactions": {
-                "accounts": [
-                    test_acct
-                ],
-                "_filter": [{"blockNumber": [{"==": 3313868}]}]
-            }
-        }
-    }
-
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactTokensForTokensSupportingFeeOnTransferTokens'"
-                 f" scraping at {time.strftime('%X')}")
-    items_scraped = await subscrape.scrape(config)
-    assert len(items_scraped) >= 1
-    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-    transaction_found = False
-    for timestamp in transactions:
-        tx = transactions[timestamp]
-        if tx['hash'] == '0xbc065d9aa4fd90a0fb1df3ddfaab633cd3866e5dc069c6ce47f33593d3aa8972':
-            transaction_found = True
-            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-            assert tx['input_a_token_symbol'] == 'WMOVR'
-            assert tx['output_a_token_symbol'] == 'BTC.m'
-            _assert_value_within_range(tx['input_a_quantity'], 0.008232571613605909)
-            _assert_value_within_range(tx['output_a_quantity'], 0.00000302)
-        else:
-            continue
-    assert transaction_found
-
-
-@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
-@pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapTokensForExactETH():
-    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= with equal block number. Two hops.
-    test_acct = "0xfc2f3c2b6872d6ad347e78f096026274326ab081"
-    config = {
-        "moonriver": {
-            "account_transactions": {
-                "accounts": [
-                    test_acct
-                ],
-                "_filter": [{"blockNumber": [{"<=": 3427502}, {">=": 3427502}]}]
-            }
-        }
-    }
-
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapTokensForExactETH'"
-                 f" scraping at {time.strftime('%X')}")
-    items_scraped = await subscrape.scrape(config)
-    assert len(items_scraped) >= 1
-    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-    transaction_found = False
-    for timestamp in transactions:
-        tx = transactions[timestamp]
-        if tx['hash'] == '0x1b036cd6d161622a5f610680b2fc15aee96103a4a884d9338ecb59f65b31753f':
-            transaction_found = True
-            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-            assert tx['input_a_token_symbol'] == 'FTM.m'
-            assert tx['output_a_token_symbol'] == 'WMOVR'
-            _assert_value_within_range(tx['input_a_quantity'], 1.507652227912820355)
-            _assert_value_within_range(tx['output_a_quantity'], 0.06)
-        else:
-            continue
-    assert transaction_found
-
-
-@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
-@pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapTokensForExactTokens():
+async def test__decode_token_swap_tx_Huckleberry__swapTokensForExactTokens():
     # also testing: swap transaction on Huckleberry DEX. "timeStamp" range in <= >= order. Two hop.
     test_acct = "0xfc2f3c2b6872d6ad347e78f096026274326ab081"
     config = {
@@ -303,7 +195,7 @@ async def test__decode_token_swap_transaction__swapTokensForExactTokens():
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapTokensForExactTokens'"
+    logging.info(f"begin 'test__decode_token_swap_tx_Huckleberry__swapTokensForExactTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -325,7 +217,190 @@ async def test__decode_token_swap_transaction__swapTokensForExactTokens():
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swapExactNativeCurrencyForTokens():
+async def test__decode_token_swap_tx_Huckleberry__swapExactTokensForTokensSupportingFeeOnTransferTokens():
+    # also testing: swap transaction on Huckleberry DEX. filter '==' on blockNumber
+    test_acct = "0x85cf0915c8d3695b03da739e3eaefd5388eb5eef"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3313868}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Huckleberry__swapExactTokensForTokensSupportingFeeOnTransferTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    logging.info('Note: for this specific unit test, subscrape will emit a warning like "expected log decoded output'
+                 ' quantity 3.02e-06 to be within 20% of the requested tx output quantity 0.0 but its not."'
+                 ' Evidently the original contract call set amountOutMin=0 so this is expected behavior.')
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xbc065d9aa4fd90a0fb1df3ddfaab633cd3866e5dc069c6ce47f33593d3aa8972':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'BTC.m'
+            _assert_value_within_range(tx['input_a_quantity'], 0.008232571613605909)
+            _assert_value_within_range(tx['output_a_quantity'], 0.00000302)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Solarbeam__swapExactTokensForETH():
+    # also testing: swap transaction on Solarbeam DEX. filter '==' on blockNumber
+    test_acct = "0x299cd1c791464827ddfb147612244a2c59da91a0"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3471171}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Solarbeam__swapExactTokensForETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x0f379919b8dff50c1d83cf92c3aa7eca75e5558251ecf99e9e7fb660faf74c95':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'FRAX'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 100)
+            _assert_value_within_range(tx['output_a_quantity'], 11.526796881289545)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Huckleberry__swapExactETHForTokens():
+    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= order. two hop tx
+    test_acct = "0x8e7fbb49f436d0e8a50c02f631e729a57a9a0aca"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"<=": 3421768}, {">=": 3421760}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Huckleberry__swapExactETHForTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xf4a51bb43a24e5bf7047d563ec831762659a1535bdbcb056764ac4298f4d3b08':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'DOT.m'
+            _assert_value_within_range(tx['input_a_quantity'], 1)
+            _assert_value_within_range(tx['output_a_quantity'], 1.2598567127)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Huckleberry__swapTokensForExactETH():
+    # also testing: swap transaction on Huckleberry DEX. "blockNumber" range in <= >= with equal block number. Two hops.
+    test_acct = "0xfc2f3c2b6872d6ad347e78f096026274326ab081"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"<=": 3427502}, {">=": 3427502}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Huckleberry__swapTokensForExactETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x1b036cd6d161622a5f610680b2fc15aee96103a4a884d9338ecb59f65b31753f':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'FTM.m'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 1.507652227912820355)
+            _assert_value_within_range(tx['output_a_quantity'], 0.06)
+        else:
+            continue
+    assert transaction_found
+
+
+# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+# @pytest.mark.asyncio
+# async def test__decode_token_swap_tx__swapETHForExactTokens():
+#     # also testing:
+#     test_acct = "XXXXXXXXXXXXX"
+#     config = {
+#         "moonriver": {
+#             "account_transactions": {
+#                 "accounts": [
+#                     test_acct
+#                 ],
+#                 "_filter": [{"blockNumber": [{"==": XXXXXXX}]}]
+#             }
+#         }
+#     }
+#
+#     logging.info(f"begin 'test__decode_token_swap_tx__swapETHForExactTokens'"
+#                  f" scraping at {time.strftime('%X')}")
+#     items_scraped = await subscrape.scrape(config)
+#     assert len(items_scraped) >= 1
+#     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+#     transaction_found = False
+#     for timestamp in transactions:
+#         tx = transactions[timestamp]
+#         if tx['hash'] == 'XXXXXXXXXXXXXXXXX':
+#             transaction_found = True
+#             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+#             assert tx['input_a_token_symbol'] == 'XXXX'
+#             assert tx['output_a_token_symbol'] == 'XXXX'
+#             _assert_value_within_range(tx['input_a_quantity'], 1111111)
+#             _assert_value_within_range(tx['output_a_quantity'], 1111111)
+#         else:
+#             continue
+#     assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Zenlink__swapExactNativeCurrencyForTokens():
     # also testing: swap transaction on Zenlink DEX.
     test_acct = "0xe1fa699860444be91d366c21de8fef56e3dec77a"
     config = {
@@ -339,7 +414,7 @@ async def test__decode_token_swap_transaction__swapExactNativeCurrencyForTokens(
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction__swapExactNativeCurrencyForTokens'"
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapExactNativeCurrencyForTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -359,10 +434,119 @@ async def test__decode_token_swap_transaction__swapExactNativeCurrencyForTokens(
     assert transaction_found
 
 
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Zenlink__swapExactTokensForNativeCurrency():
+    # also testing: swap transaction on Zenlink DEX.
+    test_acct = "0x335391f2006c318dc318230bdec020031d7dac75"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 1221284}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapExactTokensForNativeCurrency'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xd1139087f55ac1b9d377c408afed9ca86478b725f7266d7c5d15e22ba5cd1a81':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'USDC'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 1185.327082)
+            _assert_value_within_range(tx['output_a_quantity'], 6.056467880187909967)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Zenlink__swapTokensForExactNativeCurrency():
+    # also testing: swap transaction on Zenlink DEX.
+    test_acct = "0x8fbebbb93019dc8e56630507e206d8ad00842d41"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 1219176}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapTokensForExactNativeCurrency'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xf72916c26906789b1b6768d8347652e47d042181f8a1545ebbe80018fa2ce111':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'ZLK'
+            assert tx['output_a_token_symbol'] == 'WMOVR'
+            _assert_value_within_range(tx['input_a_quantity'], 963.663306508578689591)
+            _assert_value_within_range(tx['output_a_quantity'], 10)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_token_swap_tx_Zenlink__swapNativeCurrencyForExactTokens():
+    # also testing: swap transaction on Zenlink DEX.
+    test_acct = "0x9191c75bb0681a71f7d254484f2eb749c8934dac"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 1218897}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_token_swap_tx_Zenlink__swapNativeCurrencyForExactTokens'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0xc28ed3d98f9e6404828b73280eda5db1cc19aaca70dac03fed62bfdbf2273431':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'ZLK'
+            _assert_value_within_range(tx['input_a_quantity'], 10.591632213710223118)
+            _assert_value_within_range(tx['output_a_quantity'], 1000)
+        else:
+            continue
+    assert transaction_found
+
+
 @pytest.mark.skipif(not new_only or test_scope not in {'kbtc'},
                     reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_token_swap_transaction__swap():
+async def test__decode_token_swap_tx_SolarbeamStableSwap__swap():
     # also testing: StableSwap AMM on Solarbeam DEX.
     test_acct = "0x27e6a60146c5341d2e5577b219a2961f2d180579"
     config = {
@@ -376,7 +560,7 @@ async def test__decode_token_swap_transaction__swap():
         }
     }
 
-    logging.info(f"begin 'test__decode_token_swap_transaction__swap'"
+    logging.info(f"begin 'test__decode_token_swap_tx_SolarbeamStableSwap__swap'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -396,8 +580,9 @@ async def test__decode_token_swap_transaction__swap():
     assert transaction_found
 
 
+# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'swaps'}, reason="reduce API queries during debug/dev")
 # @pytest.mark.asyncio
-# async def test__decode_token_swap_transaction__():
+# async def test__decode_token_swap_tx__():
 #     # also testing: swap transaction on Zenlink DEX.
 #     test_acct = "XXXXXXXXXXXXX"
 #     config = {
@@ -411,7 +596,7 @@ async def test__decode_token_swap_transaction__swap():
 #         }
 #     }
 #
-#     logging.info(f"begin 'test__decode_token_swap_transaction__'"
+#     logging.info(f"begin 'test__decode_token_swap_tx__'"
 #                  f" scraping at {time.strftime('%X')}")
 #     items_scraped = await subscrape.scrape(config)
 #     assert len(items_scraped) >= 1
@@ -437,7 +622,7 @@ async def test__decode_token_swap_transaction__swap():
 
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_add_liquidity_transaction__addLiquidity():
+async def test__decode_add_liquidity_tx_Zenlink__addLiquidity():
     # also testing: Zenlink transactions
     test_acct = "0xa3d2c4af7496069d264e9357f9f39f79a656a1c8"
     config = {
@@ -451,7 +636,7 @@ async def test__decode_add_liquidity_transaction__addLiquidity():
         }
     }
 
-    logging.info(f"begin 'test__decode_add_liquidity_transaction__addLiquidity'"
+    logging.info(f"begin 'test__decode_add_liquidity_tx_Zenlink__addLiquidity'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -473,10 +658,48 @@ async def test__decode_add_liquidity_transaction__addLiquidity():
     assert transaction_found
 
 
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_add_liquidity_tx_Solarbeam__addLiquidityETH():
+    # also testing:
+    test_acct = "0xc794047d59f11bef4035241ab403c9a419d7da8d"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 3513919}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_add_liquidity_tx_Solarbeam__addLiquidityETH'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x6c56b95468fc04805d4d714ddd8edd46e61548a095460b7f912de7303383c3bf':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'MFAM'
+            assert tx['input_b_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'SLP'
+            _assert_value_within_range(tx['input_a_quantity'], 109972.053560515580176075)
+            _assert_value_within_range(tx['input_b_quantity'], 23.840224856355448048)
+            _assert_value_within_range(tx['output_a_quantity'], 1520.682022451843464574)
+        else:
+            continue
+    assert transaction_found
+
+
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
                     reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_add_liquidity_transaction__addLiquidityNativeCurrency():
+async def test__decode_add_liquidity_tx_Zenlink__addLiquidityNativeCurrency():
     # also testing: Zenlink transactions
     test_acct = "0x725f5b2e92164c38ef25a70f0807b71a7f0e770a"
     config = {
@@ -490,7 +713,7 @@ async def test__decode_add_liquidity_transaction__addLiquidityNativeCurrency():
         }
     }
 
-    logging.info(f"begin 'test__decode_add_liquidity_transaction__addLiquidityNativeCurrency'"
+    logging.info(f"begin 'test__decode_add_liquidity_tx_Zenlink__addLiquidityNativeCurrency'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -512,46 +735,85 @@ async def test__decode_add_liquidity_transaction__addLiquidityNativeCurrency():
     assert transaction_found
 
 
-# this Zenlink ETH/vETH -> LP requires a large refactor. Therefore ignore for now.
-# @pytest.mark.asyncio
-# async def test__decode_add_liquidity_transaction__addLiquiditySingleToken():
-#     # also testing: Zenlink exchange ETH for vETH and receive ZLK-LP
-#     test_acct = "0x0a83985e4a6e8dae2b67bed4f2d9268f6806ce00"
-#     config = {
-#         "moonriver": {
-#             "account_transactions": {
-#                 "accounts": [
-#                     test_acct
-#                 ],
-#                 "_filter": [{"blockNumber": [{"==": 2411562}]}]
-#             }
-#         }
-#     }
-#
-#     logging.info(f"begin 'test__decode_add_liquidity_transaction__addLiquiditySingleToken'"
-#                  f" scraping at {time.strftime('%X')}")
-#     items_scraped = await subscrape.scrape(config)
-#     assert len(items_scraped) >= 1
-#     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-#     transaction_found = False
-#     for timestamp in transactions:
-#         tx = transactions[timestamp]
-#         if tx['hash'] == '0x311d38bf46501961abdee8c9d808f9990fb7d91bd658039022bedd05ccad4581':
-#             transaction_found = True
-#             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-#             assert tx['input_a_token_symbol'] == 'ETH'
-#             assert tx['output_a_token_symbol'] == 'ZLK-LP'
-#             _assert_value_within_range(tx['input_a_quantity'], 0.0218565212226356)
-#             _assert_value_within_range(tx['output_a_quantity'], 0.023807051928692573)
-#         else:
-#             continue
-#     assert transaction_found
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
+                    reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_add_liquidity_tx_Zenlink__addLiquiditySingleNativeCurrency():
+    test_acct = "0x9f7aa4f003817352e9770e579be7efcd37ba1990"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 1222466}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_add_liquidity_tx_Zenlink__addLiquiditySingleNativeCurrency'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x67f837a13804964808ff8d92a20ecadd9087ec352a2ce0524667c52022775169':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'WMOVR'
+            assert tx['output_a_token_symbol'] == 'ZLK-LP'
+            _assert_value_within_range(tx['input_a_quantity'], 7.523520565458797)
+            _assert_value_within_range(tx['output_a_quantity'], 0.000051110515327605)
+        else:
+            continue
+    assert transaction_found
+
+
+@pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
+                    reason="reduce API queries during debug/dev")
+@pytest.mark.asyncio
+async def test__decode_add_liquidity_tx_Zenlink__addLiquiditySingleToken():
+    # Testing Zenlink exchange ETH for vETH and receive ZLK-LP
+    # Oddly this transaction only specifies ETH->vETH in the token path instead of full ETH->vETH->ZLK-LP.
+    # The series of events are ETH->vETH, send vETH back to acct, then provide both ETH and vETH for ZLK-LP.
+    test_acct = "0x0a83985e4a6e8dae2b67bed4f2d9268f6806ce00"
+    config = {
+        "moonriver": {
+            "account_transactions": {
+                "accounts": [
+                    test_acct
+                ],
+                "_filter": [{"blockNumber": [{"==": 2411562}]}]
+            }
+        }
+    }
+
+    logging.info(f"begin 'test__decode_add_liquidity_tx_Zenlink__addLiquiditySingleToken'"
+                 f" scraping at {time.strftime('%X')}")
+    items_scraped = await subscrape.scrape(config)
+    assert len(items_scraped) >= 1
+    transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
+    transaction_found = False
+    for timestamp in transactions:
+        tx = transactions[timestamp]
+        if tx['hash'] == '0x311d38bf46501961abdee8c9d808f9990fb7d91bd658039022bedd05ccad4581':
+            transaction_found = True
+            logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
+            assert tx['input_a_token_symbol'] == 'ETH'
+            assert tx['output_a_token_symbol'] == 'ZLK-LP'
+            _assert_value_within_range(tx['input_a_quantity'], 0.04364793008913)
+            _assert_value_within_range(tx['output_a_quantity'], 0.023807051928692573)
+        else:
+            continue
+    assert transaction_found
 
 
 @pytest.mark.skipif(not new_only or test_scope not in {'kbtc'},
                     reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
+async def test__decode_add_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_solarbeam():
     # also testing: Add liquidity to kBTC-BTC StableSwap on Solarbeam DEX.
     test_acct = "0xc365926c71dae2c7e39d176c9406239318301a3c"
     config = {
@@ -565,7 +827,7 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
         }
     }
 
-    logging.info(f"begin 'test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam'"
+    logging.info(f"begin 'test__decode_add_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_solarbeam'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -585,9 +847,10 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
     assert transaction_found
 
 
+# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
 # @pytest.mark.asyncio
-# async def test__decode_add_liquidity_transaction__():
-#     # also testing: Zenlink transactions
+# async def test__decode_add_liquidity_tx__():
+#     # also testing:
 #     test_acct = "XXXXXXXXXX"
 #     config = {
 #         "moonriver": {
@@ -595,12 +858,12 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
 #                 "accounts": [
 #                     test_acct
 #                 ],
-#                 "_filter": [{"blockNumber": [{"==": }]}]
+#                 "_filter": [{"blockNumber": [{"==": xxxxxxxxxx}]}]
 #             }
 #         }
 #     }
 #
-#     logging.info(f"begin 'test__decode_add_liquidity_transaction__XXXXXXXXXXXXXXXX'"
+#     logging.info(f"begin 'test__decode_add_liquidity_tx__XXXXXXXXXXXXXXXX'"
 #                  f" scraping at {time.strftime('%X')}")
 #     items_scraped = await subscrape.scrape(config)
 #     assert len(items_scraped) >= 1
@@ -611,49 +874,12 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
 #         if tx['hash'] == 'XXXXXXXXXXX':
 #             transaction_found = True
 #             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-#             assert tx['input_a_token_symbol'] == 'xcKSM'
-#             assert tx['input_b_token_symbol'] == 'WMOVR'
-#             assert tx['output_a_token_symbol'] == 'ZLK-LP'
-#             _assert_value_within_range(tx['input_a_quantity'], 3.635995421334)
-#             _assert_value_within_range(tx['input_b_quantity'], 14.999999999996282704)
-#             _assert_value_within_range(tx['output_a_quantity'], 1)
-#         else:
-#             continue
-#     assert transaction_found
-
-
-# @pytest.mark.asyncio
-# async def test__decode_add_liquidity_transaction__():
-#     # also testing: Zenlink transactions
-#     test_acct = "XXXXXXXXXX"
-#     config = {
-#         "moonriver": {
-#             "account_transactions": {
-#                 "accounts": [
-#                     test_acct
-#                 ],
-#                 "_filter": [{"blockNumber": [{"==": }]}]
-#             }
-#         }
-#     }
-#
-#     logging.info(f"begin 'test__decode_add_liquidity_transaction__XXXXXXXXXXXXXXXX'"
-#                  f" scraping at {time.strftime('%X')}")
-#     items_scraped = await subscrape.scrape(config)
-#     assert len(items_scraped) >= 1
-#     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
-#     transaction_found = False
-#     for timestamp in transactions:
-#         tx = transactions[timestamp]
-#         if tx['hash'] == 'XXXXXXXXXXX':
-#             transaction_found = True
-#             logging.debug(f'for hash {tx["hash"]} the full transaction is {tx}')
-#             assert tx['input_a_token_symbol'] == 'xcKSM'
-#             assert tx['input_b_token_symbol'] == 'WMOVR'
-#             assert tx['output_a_token_symbol'] == 'ZLK-LP'
-#             _assert_value_within_range(tx['input_a_quantity'], 3.635995421334)
-#             _assert_value_within_range(tx['input_b_quantity'], 14.999999999996282704)
-#             _assert_value_within_range(tx['output_a_quantity'], 1)
+#             assert tx['input_a_token_symbol'] == 'xxxxxx'
+#             assert tx['input_b_token_symbol'] == 'xxxxxx'
+#             assert tx['output_a_token_symbol'] == 'xxxxxxx'
+#             _assert_value_within_range(tx['input_a_quantity'], xxxxxx)
+#             _assert_value_within_range(tx['input_b_quantity'], xxxxxxx)
+#             _assert_value_within_range(tx['output_a_quantity'], xxxxxxxxx)
 #         else:
 #             continue
 #     assert transaction_found
@@ -663,8 +889,9 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
 # ######### REMOVE LIQUIDITY TESTS ############################
 # #############################################################
 
+# @pytest.mark.skipif(not new_only or test_scope not in {'all', 'liquidity'}, reason="reduce API queries during debug/dev")
 # @pytest.mark.asyncio
-# async def test__decode_remove_liquidity_transaction__():
+# async def test__decode_remove_liquidity_tx__():
 #     # also testing: Zenlink transactions
 #     test_acct = "XXXXXXXXXX"
 #     config = {
@@ -678,7 +905,7 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
 #         }
 #     }
 #
-#     logging.info(f"begin 'test__decode_remove_liquidity_transaction__XXXXXXXXXXXXXXXX'"
+#     logging.info(f"begin 'test__decode_remove_liquidity_tx__XXXXXXXXXXXXXXXX'"
 #                  f" scraping at {time.strftime('%X')}")
 #     items_scraped = await subscrape.scrape(config)
 #     assert len(items_scraped) >= 1
@@ -703,7 +930,7 @@ async def test__decode_add_liquidity_transaction__kbtc_stableswap_solarbeam():
 @pytest.mark.skipif(new_only or test_scope not in {'all', 'liquidity'},
                     reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_remove_liquidity_transaction__removeLiquidityNativeCurrency():
+async def test__decode_remove_liquidity_tx_Zenlink__removeLiquidityNativeCurrency():
     # also testing: Zenlink transactions
     test_acct = "0x96cc80292fa3a7045611eb84ae09df8bd15936d2"
     config = {
@@ -717,7 +944,7 @@ async def test__decode_remove_liquidity_transaction__removeLiquidityNativeCurren
         }
     }
 
-    logging.info(f"begin 'test__decode_remove_liquidity_transaction__removeLiquidityNativeCurrency'"
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_Zenlink__removeLiquidityNativeCurrency'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1
@@ -742,7 +969,7 @@ async def test__decode_remove_liquidity_transaction__removeLiquidityNativeCurren
 @pytest.mark.skipif(not new_only or test_scope not in {'kbtc'},
                     reason="reduce API queries during debug/dev")
 @pytest.mark.asyncio
-async def test__decode_remove_liquidity_transaction__kbtc_stableswap_solarbeam():
+async def test__decode_remove_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_solarbeam():
     # also testing: Remove liquidity from kBTC-BTC StableSwap on Solarbeam DEX.
     test_acct = "0xb4c9531a60e252c871d51923bc9f153f1d371ca8"
     config = {
@@ -756,7 +983,7 @@ async def test__decode_remove_liquidity_transaction__kbtc_stableswap_solarbeam()
         }
     }
 
-    logging.info(f"begin 'test__decode_remove_liquidity_transaction__kbtc_stableswap_solarbeam'"
+    logging.info(f"begin 'test__decode_remove_liquidity_tx_SolarbeamStableSwap__kbtc_stableswap_solarbeam`'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
     assert len(items_scraped) >= 1

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -93,4 +93,3 @@ def assert_value_within_range(actual, expected, tolerance_percent=1):
     upper_limit = expected_float + tolerance
     assert actual_float >= lower_limit
     assert actual_float <= upper_limit
-

--- a/tests/test_moonbeam_scraper.py
+++ b/tests/test_moonbeam_scraper.py
@@ -68,7 +68,7 @@ async def test__no_entries_returned():
 @pytest.mark.asyncio
 async def test__decode_token_swap_tx_Solarbeam__swapExactTokensForTokens():
     # also testing: swap transaction on Solarbeam DEX. filter range on "timeStamp"
-    test_acct = "0xBa4123F4b2da090aeCef69Fd0946D42Ecd4C788E"
+    test_acct = "0xba4123f4b2da090aecef69fd0946d42ecd4c788e"
     config = {
         "moonriver": {
             "account_transactions": {
@@ -234,9 +234,6 @@ async def test__decode_token_swap_tx_Huckleberry__swapExactTokensForTokensSuppor
     logging.info(f"begin 'test__decode_token_swap_tx_Huckleberry__swapExactTokensForTokensSupportingFeeOnTransferTokens'"
                  f" scraping at {time.strftime('%X')}")
     items_scraped = await subscrape.scrape(config)
-    logging.info('Note: for this specific unit test, subscrape will emit a warning like "expected log decoded output'
-                 ' quantity 3.02e-06 to be within 20% of the requested tx output quantity 0.0 but its not."'
-                 ' Evidently the original contract call set amountOutMin=0 so this is expected behavior.')
     assert len(items_scraped) >= 1
     transactions = _get_archived_transactions_from_json(test_acct, 'moonriver')
     transaction_found = False


### PR DESCRIPTION
## Description

Feature Fixes:
* Improve filtering to support Moonriver and filter '==', '<=', '>=' on both 'timeStamp' and 'blockNumber'.
    This allows the unit tests to request only a single block or time range from the block explorers instead of an account's full transaction history, significantly reducing the unit test execution time.
* don't check "actual vs requested" values if requested value was zero.
* when exporting transactions, check what type of structure is being
passed in, to determine how/whether to export to Excel.
* standardize using lowercase versions of EVM addresses. Some
interfaces were returning capital letters, causing string comparisons
to fail. (this might be checksum encoding, but we don't need it.)
* refactor `removeLiquidity` to handle situation where tokens from
burned LP are not in the same order as initial request (similar pattern
from `addLiquidity`).
* add/remove liquidity - support Deposit/Withdraw events, which might
hold the other part of tokens being transferred.
* refactor `add_liquidity` to support single-sided LP creation (ignore
intermediate tokens)
* PEP8 cleanup includes substrate sections of code

* add unit tests for the following "token swap" methods
  * swapExactTokensForTokens
  * swapExactTokensForETH
  * swapExactETHForTokens
  * swapExactTokensForTokensSupportingFeeOnTransferTokens
  * swapTokensForExactETH
  * swapTokensForExactTokens
  * swapExactNativeCurrencyForTokens
  * swapExactTokensForNativeCurrency
  * swapTokensForExactNativeCurrency
  * swapNativeCurrencyForExactTokens
* add unit tests for the following "add liquidity" methods:
  * addLiquidity
  * addLiquidityETH
  * addLiquidityNativeCurrency
  * addLiquiditySingleNativeCurrency
  * addLiquiditySingleToken
* add unit tests for the following "remove liquidity" methods:
  * removeLiquidity
  * removeLiquidityWithPermit
  * removeLiquidityETH
  * removeLiquidityETHSupportingFeeOnTransferTokens
  * removeLiquidityETHWithPermitSupportingFeeOnTransferTokens
  * removeLiquidityNativeCurrency
* other unit tests:
  * added unit tests for Solarbeam's StableSwap also, but untested since I haven't written the cooresponding implementation yet.
  * add a unit test for failure case where tx query returns no results
  * add debug ability to skip sets of unit tests to help focus on
  new/changing tests.
The unit tests cover Solarbeam, Huckleberry, and Zenlink including several multi-hop transactions

no unit tests yet for deposit, withdrawal, or redeem methods.